### PR TITLE
support react 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "warning": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
We use react 15.x and would like to use a maintained version of react-router 2.x but we cant because the current peer deps is set to either 14.x or 16.x 

```
npm ERR! peer invalid: react@^0.14.0 || ^16.0.0, required by react-router-two-legacy@2.10.1
```

This pr adds 15.x to the peerDeps